### PR TITLE
Add HTTP transport support with configurable port

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,28 @@ Or in development mode:
 uv run dhlab-mcp
 ```
 
+### Running as a Local HTTP API
+
+To run the MCP server as a local HTTP API on a custom port:
+
+```bash
+# Run on default port 8000
+dhlab-mcp --transport http
+
+# Run on a custom port
+dhlab-mcp --transport http --port 9000
+
+# Run on a specific host and port
+dhlab-mcp --transport http --host 0.0.0.0 --port 8080
+```
+
+The server supports the following transport options:
+- `stdio` (default): Standard input/output for CLI integration
+- `http`: Streamable HTTP transport (recommended for network access)
+- `sse`: Server-Sent Events transport (legacy, for backward compatibility)
+
+Once running, the HTTP server will be available at `http://<host>:<port>/mcp/`.
+
 ### Available Tools
 
 #### 1. `search_texts`

--- a/src/dhlab_mcp/server.py
+++ b/src/dhlab_mcp/server.py
@@ -295,7 +295,33 @@ def get_corpus_statistics(urns: list[str]) -> str:
 
 def main():
     """Run the MCP server."""
-    mcp.run()
+    import argparse
+
+    parser = argparse.ArgumentParser(description="DHLAB MCP Server")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "http", "sse"],
+        default="stdio",
+        help="Transport protocol (default: stdio)",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind to when using http/sse transport (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to bind to when using http/sse transport (default: 8000)",
+    )
+
+    args = parser.parse_args()
+
+    if args.transport in ("http", "sse"):
+        mcp.run(transport=args.transport, host=args.host, port=args.port)
+    else:
+        mcp.run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add CLI arguments for `--transport`, `--host`, and `--port` to run the MCP server as a local HTTP API
- Support three transport modes: `stdio` (default), `http` (recommended for network), and `sse` (legacy)
- Document usage examples in README

## Test plan
- [x] Verify `dhlab-mcp --help` shows new options
- [x] Verify `dhlab-mcp --transport http --port 9001` starts server correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)