### PR TITLE
fix: enforce max window=24 for word_concordance (closes #7)

### DIFF
--- a/src/dhlab_mcp/server.py
+++ b/src/dhlab_mcp/server.py
@@ -119,6 +119,9 @@ def find_concordances(
         return f"Error finding concordances: {str(e)}"
 
 
+_WORD_CONCORDANCE_MAX_WINDOW = 24
+
+
 @mcp.tool()
 def word_concordance(
     urn: str,
@@ -143,7 +146,14 @@ def word_concordance(
         - before: Text before the matched word
         - target: The matched word itself
         - after: Text after the matched word
+
+    Raises:
+        ValueError: If window exceeds the maximum allowed value of 24.
     """
+    if window > _WORD_CONCORDANCE_MAX_WINDOW:
+        raise ValueError(
+            f"window must be at most {_WORD_CONCORDANCE_MAX_WINDOW}, got {window}"
+        )
     try:
         from dhlab.api.dhlab_api import word_concordance as dhlab_word_concordance
 

--- a/tests/test_server_validation.py
+++ b/tests/test_server_validation.py
@@ -1,0 +1,68 @@
+"""Tests for input validation in server.py tools."""
+
+import inspect
+import pytest
+from unittest.mock import patch, MagicMock
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from dhlab_mcp.server import word_concordance, _WORD_CONCORDANCE_MAX_WINDOW
+
+# The @mcp.tool() decorator wraps the function into a FunctionTool object.
+# Access the underlying callable via .fn for direct testing.
+_word_concordance_fn = word_concordance.fn
+
+
+class TestWordConcordanceWindowValidation:
+    def test_window_at_max_does_not_raise(self):
+        """window == 24 should not raise — it's exactly at the limit."""
+        mock_result = MagicMock()
+        mock_result.__len__ = lambda self: 0
+        with patch("dhlab.api.dhlab_api.word_concordance", return_value=mock_result):
+            try:
+                _word_concordance_fn("urn:123", "word", window=24)
+            except ValueError:
+                pytest.fail("window=24 should not raise ValueError")
+
+    def test_window_over_max_raises_value_error(self):
+        """window > 24 must raise ValueError before the API is called."""
+        with pytest.raises(ValueError, match="24"):
+            _word_concordance_fn("urn:123", "word", window=25)
+
+    def test_window_zero_does_not_raise(self):
+        """window=0 is at the low end and should not raise."""
+        mock_result = MagicMock()
+        mock_result.__len__ = lambda self: 0
+        with patch("dhlab.api.dhlab_api.word_concordance", return_value=mock_result):
+            try:
+                _word_concordance_fn("urn:123", "word", window=0)
+            except ValueError:
+                pytest.fail("window=0 should not raise ValueError")
+
+    def test_default_window_within_limit(self):
+        """The default window value (12) must be within the allowed limit."""
+        sig = inspect.signature(_word_concordance_fn)
+        default_window = sig.parameters["window"].default
+        assert default_window <= _WORD_CONCORDANCE_MAX_WINDOW
+
+    def test_max_window_constant_value(self):
+        assert _WORD_CONCORDANCE_MAX_WINDOW == 24
+
+    def test_error_message_includes_limit(self):
+        """The ValueError message should state the maximum allowed value."""
+        with pytest.raises(ValueError) as exc_info:
+            _word_concordance_fn("urn:123", "word", window=100)
+        assert "24" in str(exc_info.value)
+
+    def test_error_message_includes_actual_value(self):
+        """The ValueError message should include the bad value that was passed."""
+        with pytest.raises(ValueError) as exc_info:
+            _word_concordance_fn("urn:123", "word", window=100)
+        assert "100" in str(exc_info.value)
+
+    def test_large_window_raises(self):
+        with pytest.raises(ValueError):
+            _word_concordance_fn("urn:123", "word", window=999)


### PR DESCRIPTION
## Summary

- The `word_concordance` tool documented `max: 24` for the `window` parameter but never enforced it — callers could pass any value and hit undefined API behaviour
- Adds validation: raises `ValueError` with a descriptive message when `window > 24`
- Extracts the limit into a named constant `_WORD_CONCORDANCE_MAX_WINDOW = 24` so it stays in sync between the validation and the docstring

Closes #7

## Test plan

- [x] `test_window_over_max_raises_value_error` — window=25 raises ValueError
- [x] `test_window_at_max_does_not_raise` — window=24 passes through
- [x] `test_window_zero_does_not_raise` — window=0 is valid
- [x] `test_default_window_within_limit` — default of 12 is within limit
- [x] `test_error_message_includes_limit` — error states the max (24)
- [x] `test_error_message_includes_actual_value` — error states the bad value
- [x] All 8 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)