### PR TITLE
fix(test): drop unused pytest import in test_server_extra.py

### DIFF
--- a/tests/test_server_extra.py
+++ b/tests/test_server_extra.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 # ---------------------------------------------------------------------------
 # find_concordances


### PR DESCRIPTION
Ruff F401 was failing on main since #11 merged — test file uses unittest.mock only, no pytest features. Removing the import.

## Test plan
- [x] `uvx ruff check` clean locally
- [ ] CI green on this PR