### PR TITLE
fix(test): drop unused result assignment in test_avis_corpus_uses_ngramnews

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -118,7 +118,7 @@ class TestNgramFrequencies:
         ng = self._make_ng({"1950": 0.002})
         with patch("dhlab_mcp.server.dhlab") as mock_dhlab:
             mock_dhlab.NgramNews.return_value = ng
-            result = ngram_frequencies.fn(["avis"], corpus="avis")
+            ngram_frequencies.fn(["avis"], corpus="avis")
         mock_dhlab.NgramNews.assert_called_once()
 
     def test_no_data_returns_message(self):


### PR DESCRIPTION
Ruff F841 on main since #10 merged — line 121 captured `ngram_frequencies.fn` into a `result` var never asserted against (assertion checks the mock was called). Sibling test on line 129 captures result and DOES use it — leaving that alone.

## Test plan
- [x] `uvx ruff check` clean
- [ ] CI green