### PR TITLE
fix: search_images drops dead from_year/to_year params

### DIFF
--- a/src/dhlab_mcp/server.py
+++ b/src/dhlab_mcp/server.py
@@ -253,19 +253,20 @@ def lookup_word_lemma(word: str) -> str:
 def search_images(
     query: str,
     limit: int = 10,
-    from_year: int | None = None,
-    to_year: int | None = None,
 ) -> str:
     """Search for images in the National Library's digital collection.
 
     Args:
         query: Search query string
         limit: Maximum number of results (default: 10)
-        from_year: Start year (optional)
-        to_year: End year (optional)
 
     Returns:
         JSON string containing image search results with URLs
+
+    Note:
+        The underlying ``dhlab.images.nbpictures.find_urls`` API does not
+        currently support year filtering. If date scoping is added upstream,
+        ``from_year`` / ``to_year`` parameters can be re-added here.
     """
     try:
         from dhlab.images.nbpictures import find_urls

--- a/tests/test_server_extra.py
+++ b/tests/test_server_extra.py
@@ -240,6 +240,17 @@ class TestSearchImages:
 
         mock_fn.assert_called_once_with(term="oslo", number=5, mediatype="bilder")
 
+    def test_signature_does_not_accept_year_params(self):
+        """Regression: from_year / to_year were previously declared on the
+        tool but silently ignored by the underlying find_urls (which has no
+        date filter). The signature now omits them so MCP clients see the
+        accurate API surface instead of dead parameters."""
+        import inspect
+        from dhlab_mcp.server import search_images
+        sig = inspect.signature(search_images.fn)
+        assert "from_year" not in sig.parameters
+        assert "to_year" not in sig.parameters
+
 
 # ---------------------------------------------------------------------------
 # get_corpus_statistics


### PR DESCRIPTION
## Bug

\`search_images\` declared \`from_year\` and \`to_year\` filter parameters and documented them in the tool description, but the underlying \`dhlab.images.nbpictures.find_urls\` doesn't support date filtering at all:

\`\`\`python
>>> inspect.signature(find_urls)
(term, number=50, page=0, mediatype='bilder')
\`\`\`

The MCP tool ignored both year params silently — clients passing year filters got unfiltered results with no warning. Worse for LLM-driven agents: the docstring tells them year filtering works, so they confidently pass year ranges and treat the unfiltered output as filtered.

## Fix

- Drop \`from_year\` / \`to_year\` from the \`search_images\` signature
- Drop the corresponding lines from the docstring
- Add a note explaining that if dhlab upstream adds date filtering, the params can be re-added
- Add a regression test (\`test_signature_does_not_accept_year_params\`) that pins the signature so the dead params can't drift back in

## Caveats

This is a breaking signature change in the MCP-tool API surface — clients that were passing \`from_year\`/\`to_year\` will now get an unknown-param error. But that's a strict improvement over the current silent-lie behavior: the only callers affected were ones whose filter wasn't actually being honored.

55 → 56 tests, all green.