### PR TITLE
docs: remove redundant 'uv pip install -e .' step

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ Get statistics about a set of documents.
 For development, install with:
 ```bash
 uv sync --dev
-uv pip install -e .
 ```
 
 Run tests:


### PR DESCRIPTION
`uv sync --dev` already installs the project in editable mode — the extra `uv pip install -e .` line was redundant and (for markutils) the surrounding 'so source isn't distributed to .venv' explanation was misleading because uv handles that. Same cleanup landed in [python-template#15](https://github.com/marksverdhei/python-template/pull/15); propagating to the other repos that inherited the same stale instruction.