### PR TITLE
refactor(server): extract _make_parser() so tests exercise the real production parser

### DIFF
--- a/src/dhlab_mcp/server.py
+++ b/src/dhlab_mcp/server.py
@@ -304,8 +304,11 @@ def get_corpus_statistics(urns: list[str]) -> str:
         return f"Error getting corpus statistics: {str(e)}"
 
 
-def main():
-    """Run the MCP server."""
+def _make_parser():
+    """Build the CLI argument parser. Factored out so tests can exercise the
+    actual production parser instead of re-declaring it (which is drift-prone:
+    any new flag added here must also be added to the test mirror, and the
+    test passes regardless of whether main() ever wires the flag through)."""
     import argparse
 
     parser = argparse.ArgumentParser(description="DHLAB MCP Server")
@@ -326,8 +329,12 @@ def main():
         default=8000,
         help="Port to bind to when using http/sse transport (default: 8000)",
     )
+    return parser
 
-    args = parser.parse_args()
+
+def main():
+    """Run the MCP server."""
+    args = _make_parser().parse_args()
 
     if args.transport in ("http", "sse"):
         mcp.run(transport=args.transport, host=args.host, port=args.port)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import argparse
 import json
 from unittest.mock import MagicMock, patch
 
@@ -209,15 +208,11 @@ class TestLookupWordLemma:
 
 class TestMainArgParser:
     def _build_parser(self):
-        parser = argparse.ArgumentParser(description="DHLAB MCP Server")
-        parser.add_argument(
-            "--transport",
-            choices=["stdio", "http", "sse"],
-            default="stdio",
-        )
-        parser.add_argument("--host", default="127.0.0.1")
-        parser.add_argument("--port", type=int, default=8000)
-        return parser
+        # Use the real production parser — tests previously mirrored the
+        # argparse setup inline, which drifted from main() silently when
+        # flags were added or defaults changed.
+        from dhlab_mcp.server import _make_parser
+        return _make_parser()
 
     def test_default_transport_is_stdio(self):
         parser = self._build_parser()
@@ -258,3 +253,24 @@ class TestMainArgParser:
         parser = self._build_parser()
         args = parser.parse_args(["--port", "9090"])
         assert args.port == 9090
+
+    def test_main_dispatches_http_with_host_and_port(self):
+        # End-to-end main() dispatch — covers the http/sse branch which
+        # passes transport+host+port through to mcp.run.
+        from dhlab_mcp.server import main
+        from unittest.mock import patch
+        with patch("sys.argv", ["dhlab-mcp", "--transport", "http",
+                                 "--host", "0.0.0.0", "--port", "9090"]), \
+             patch("dhlab_mcp.server.mcp.run") as mock_run:
+            main()
+        mock_run.assert_called_once_with(transport="http", host="0.0.0.0", port=9090)
+
+    def test_main_dispatches_stdio_with_no_args(self):
+        # End-to-end main() dispatch — covers the stdio branch which is
+        # the default and takes no transport/host/port kwargs.
+        from dhlab_mcp.server import main
+        from unittest.mock import patch
+        with patch("sys.argv", ["dhlab-mcp"]), \
+             patch("dhlab_mcp.server.mcp.run") as mock_run:
+            main()
+        mock_run.assert_called_once_with()


### PR DESCRIPTION
## Why

Coverage report on `server.py` flagged `main()` lines 307-335 as unhit despite `TestMainArgParser` claiming to cover the argparse setup. The reason: the test re-declared the entire argparse setup inline (`_build_parser` mirror of the production parser), so the assertions only exercised a **copy** of the parser — never `main()` itself. The pattern is also drift-prone: any new flag in `main()` needed mirroring in the test mirror, and the test passed regardless of whether `main()` actually wired the new flag through.

Same antitestpattern surfaced today in syntk#56 (the bootstrap gen_kwargs forwarding). 'Mirror impl in test' produces tests that drift silently.

## What

- Factor out `_make_parser()` from `main()` so both production and tests use the same parser.
- Rewrite `TestMainArgParser._build_parser()` to call the real `_make_parser()`.
- Add two main() end-to-end dispatch tests with `sys.argv` patched + mocked `mcp.run`:
  - HTTP transport → forwards `transport` / `host` / `port` to `mcp.run`
  - stdio (default) transport → `mcp.run()` with no kwargs

## Numbers

- `server.py` coverage: **91% → 99%** (only line 346 — the `__name__` guard — remains)
- Tests: 56 → 58
- Same parser shape; same behaviour; no breaking change to anyone importing from `dhlab_mcp.server`.